### PR TITLE
Fix pagination element making content unclickable

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -1,8 +1,8 @@
-<section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+<section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   {% if page.previous %}
-    <a href="{{ site.url }}{{ page.previous.url }}" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="{{ site.url }}{{ page.previous.url }}" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   {% endif %}
   {% if page.next %}
-    <a href="{{ site.url }}{{page.next.url}}" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="{{ site.url }}{{page.next.url}}" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   {% endif %}
 </section>

--- a/_site/posts/Viterbi-POS-tagger.html
+++ b/_site/posts/Viterbi-POS-tagger.html
@@ -77,14 +77,15 @@
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
-    <a href="http://localhost:4000/posts/text-mining-in-Java" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="http://localhost:4000/posts/text-mining-in-Java" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   
   
-    <a href="http://localhost:4000/posts/fake-news-challenge" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="http://localhost:4000/posts/fake-news-challenge" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/posts/beavers.html
+++ b/_site/posts/beavers.html
@@ -74,14 +74,15 @@ in the roots of verbal meaning. See below for one of my favorite linguistics quo
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
-    <a href="http://localhost:4000/posts/dist-sem" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="http://localhost:4000/posts/dist-sem" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   
   
-    <a href="http://localhost:4000/posts/textkernel" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="http://localhost:4000/posts/textkernel" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/posts/dish-ai.html
+++ b/_site/posts/dish-ai.html
@@ -69,14 +69,15 @@
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
-    <a href="http://localhost:4000/posts/semantic-role-labeling-crf" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="http://localhost:4000/posts/semantic-role-labeling-crf" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   
   
-    <a href="http://localhost:4000/posts/thoughts-on-getting-into-graduate-school" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="http://localhost:4000/posts/thoughts-on-getting-into-graduate-school" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/posts/dist-sem.html
+++ b/_site/posts/dist-sem.html
@@ -73,14 +73,15 @@
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
-    <a href="http://localhost:4000/posts/lin-similarity" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="http://localhost:4000/posts/lin-similarity" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   
   
-    <a href="http://localhost:4000/posts/beavers" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="http://localhost:4000/posts/beavers" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/posts/edit-distances-and-sequence-alignment.html
+++ b/_site/posts/edit-distances-and-sequence-alignment.html
@@ -73,14 +73,15 @@
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
-    <a href="http://localhost:4000/posts/semantic-dependency-graph-parsing" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="http://localhost:4000/posts/semantic-dependency-graph-parsing" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   
   
-    <a href="http://localhost:4000/posts/semantic-role-labeling-crf" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="http://localhost:4000/posts/semantic-role-labeling-crf" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/posts/fake-news-challenge.html
+++ b/_site/posts/fake-news-challenge.html
@@ -73,14 +73,15 @@
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
-    <a href="http://localhost:4000/posts/Viterbi-POS-tagger" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="http://localhost:4000/posts/Viterbi-POS-tagger" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   
   
-    <a href="http://localhost:4000/posts/hpc-for-ml" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="http://localhost:4000/posts/hpc-for-ml" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/posts/how-to-get-started-in-NLP.html
+++ b/_site/posts/how-to-get-started-in-NLP.html
@@ -224,14 +224,15 @@ Somewhere I read that if you ever have to answer the same question twice, it’s
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
-    <a href="http://localhost:4000/posts/thoughts-on-getting-into-graduate-school" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="http://localhost:4000/posts/thoughts-on-getting-into-graduate-school" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   
   
-    <a href="http://localhost:4000/posts/text-mining-in-Java" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="http://localhost:4000/posts/text-mining-in-Java" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/posts/hpc-for-ml.html
+++ b/_site/posts/hpc-for-ml.html
@@ -81,14 +81,15 @@
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
-    <a href="http://localhost:4000/posts/fake-news-challenge" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="http://localhost:4000/posts/fake-news-challenge" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   
   
-    <a href="http://localhost:4000/posts/nlp-with-repl" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="http://localhost:4000/posts/nlp-with-repl" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/posts/lin-similarity.html
+++ b/_site/posts/lin-similarity.html
@@ -69,14 +69,15 @@
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
-    <a href="http://localhost:4000/posts/sentence-comprehension" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="http://localhost:4000/posts/sentence-comprehension" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   
   
-    <a href="http://localhost:4000/posts/dist-sem" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="http://localhost:4000/posts/dist-sem" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/posts/nlp-with-repl.html
+++ b/_site/posts/nlp-with-repl.html
@@ -99,12 +99,13 @@
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
-    <a href="http://localhost:4000/posts/hpc-for-ml" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="http://localhost:4000/posts/hpc-for-ml" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/posts/semantic-dependency-graph-parsing.html
+++ b/_site/posts/semantic-dependency-graph-parsing.html
@@ -69,14 +69,15 @@
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
-    <a href="http://localhost:4000/posts/string-to-semantic-graph-alignment" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="http://localhost:4000/posts/string-to-semantic-graph-alignment" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   
   
-    <a href="http://localhost:4000/posts/edit-distances-and-sequence-alignment" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="http://localhost:4000/posts/edit-distances-and-sequence-alignment" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/posts/semantic-role-labeling-crf.html
+++ b/_site/posts/semantic-role-labeling-crf.html
@@ -73,14 +73,15 @@
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
-    <a href="http://localhost:4000/posts/edit-distances-and-sequence-alignment" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="http://localhost:4000/posts/edit-distances-and-sequence-alignment" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   
   
-    <a href="http://localhost:4000/posts/dish-ai" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="http://localhost:4000/posts/dish-ai" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/posts/sentence-comprehension.html
+++ b/_site/posts/sentence-comprehension.html
@@ -69,12 +69,13 @@
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
   
-    <a href="http://localhost:4000/posts/lin-similarity" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="http://localhost:4000/posts/lin-similarity" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/posts/string-to-semantic-graph-alignment.html
+++ b/_site/posts/string-to-semantic-graph-alignment.html
@@ -73,14 +73,15 @@
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
-    <a href="http://localhost:4000/posts/textkernel" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="http://localhost:4000/posts/textkernel" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   
   
-    <a href="http://localhost:4000/posts/semantic-dependency-graph-parsing" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="http://localhost:4000/posts/semantic-dependency-graph-parsing" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/posts/text-mining-in-Java.html
+++ b/_site/posts/text-mining-in-Java.html
@@ -75,14 +75,15 @@
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
-    <a href="http://localhost:4000/posts/how-to-get-started-in-NLP" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="http://localhost:4000/posts/how-to-get-started-in-NLP" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   
   
-    <a href="http://localhost:4000/posts/Viterbi-POS-tagger" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="http://localhost:4000/posts/Viterbi-POS-tagger" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/posts/textkernel.html
+++ b/_site/posts/textkernel.html
@@ -73,14 +73,15 @@
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
-    <a href="http://localhost:4000/posts/beavers" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="http://localhost:4000/posts/beavers" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   
   
-    <a href="http://localhost:4000/posts/string-to-semantic-graph-alignment" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="http://localhost:4000/posts/string-to-semantic-graph-alignment" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/posts/thoughts-on-getting-into-graduate-school.html
+++ b/_site/posts/thoughts-on-getting-into-graduate-school.html
@@ -101,14 +101,15 @@
 <img src="http://localhost:4000/images/scribble3.png" alt="scribble" />
 
       </main>
-      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+      <section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4 pointer-events-none">
   
-    <a href="http://localhost:4000/posts/dish-ai" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="http://localhost:4000/posts/dish-ai" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3 pointer-events-all">‹</a>
   
   
-    <a href="http://localhost:4000/posts/how-to-get-started-in-NLP" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="http://localhost:4000/posts/how-to-get-started-in-NLP" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3 pointer-events-all">›</a>
   
 </section>
+
     </div>
     <footer class="mw7 center tc pt3 pb4 silver">
       Built with Jekyll using <a href="http://github.com/muan/scribble" class="link silver hover-blue pv1">Scribble</a>.

--- a/_site/stylesheets/style.css
+++ b/_site/stylesheets/style.css
@@ -38,3 +38,11 @@
   padding-left: 3.8rem;
 }
 /* end Markdown styles */
+
+.pointer-events-none {
+  pointer-events: none;
+}
+
+.pointer-events-all {
+  pointer-events: all;
+}

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -38,3 +38,11 @@
   padding-left: 3.8rem;
 }
 /* end Markdown styles */
+
+.pointer-events-none {
+  pointer-events: none;
+}
+
+.pointer-events-all {
+  pointer-events: all;
+}


### PR DESCRIPTION
Pagination links are contained in a fixed section element that's positioned over the main content, which is making anything that is scrolled underneath it unclickable.

![screen shot 2019-01-15 at 11 22 52 am](https://user-images.githubusercontent.com/6979137/51204023-9b57d680-18d0-11e9-81a5-72428a8c4f1a.png)

One way of fixing that (and what this PR does) is to disable pointer events on the main pagination element so that it doesn't block click events for the stuff behind it, and re-enabling pointer-events for the pagination links within the pagination element so that those remain clickable.